### PR TITLE
[정준호] Feature/page current state compare 

### DIFF
--- a/vms_fe/src/components/common/CompanyDataPerRow.module.css
+++ b/vms_fe/src/components/common/CompanyDataPerRow.module.css
@@ -5,7 +5,7 @@
   min-width: 697px;
   max-width: 1200px;
   height: 64px;
-  background-color: #2E2E2E;
+  background-color: #212121;
   border-radius: 4px;
 }
 

--- a/vms_fe/src/components/common/CompanyDataPerRow.module.css
+++ b/vms_fe/src/components/common/CompanyDataPerRow.module.css
@@ -22,7 +22,9 @@
 .sameSizeContainer > span,
 .companyInfoContainer > span {
   font-size: 0.875rem;
-  color: #FFFFFF;
+  font-weight: 400;
+  line-height: 16.71px;
+  color: #D8D8D8;
 }
 
 .diffSizeContainer {
@@ -61,8 +63,12 @@
   min-width: 140px;
   max-width: 213px;
   gap: 12px;
-  font-size: 0.875rem;
+}
 
+.companyInfoContainer > span {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #FFFFFF;
 }
 
 .companyInfoContainer > img {
@@ -127,4 +133,18 @@
 
 .columnNone {
   width: 64px;
+}
+
+
+@media (max-width: 744px) {
+  .companyInfoContainer > span {
+    font-size: 0.8125rem;
+  }
+
+  .diffSizeContainer > span,
+  .sameSizeContainer > span,
+  .companyInfoContainer > span {
+    font-size: 0.8125rem;
+  }
+
 }

--- a/vms_fe/src/components/common/HeaderColumns.module.css
+++ b/vms_fe/src/components/common/HeaderColumns.module.css
@@ -5,7 +5,7 @@
   min-width: 696px;
   max-width: 1200px;
   height: 39px;
-  background-color: #4B4B4B;
+  background-color:#2E2E2E;
   border-radius: 4px;
 }
 

--- a/vms_fe/src/components/common/HeaderColumns.module.css
+++ b/vms_fe/src/components/common/HeaderColumns.module.css
@@ -12,6 +12,7 @@
 .diffSizeContainer > div,
 .sameSizeContainer > span{
   font-size: 0.875rem;
+  font-weight: 500;
   color: #FFFFFF;
 }
 
@@ -114,6 +115,7 @@
 
 .wrapText > span {
   color: #FFFFFF;
+  font-weight: 500;
   font-size: 0.875rem;
 }
 
@@ -123,5 +125,18 @@
   }
 }
 
+@media (max-width: 744px) {
+  .diffSizeContainer > div,
+  .sameSizeContainer > span{
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #FFFFFF;
+  }
+
+  .wrapText > span {
+    color: #FFFFFF;
+    font-size: 0.8125rem;
+  }
+}
 
 

--- a/vms_fe/src/pages/CurrentStateCompare.js
+++ b/vms_fe/src/pages/CurrentStateCompare.js
@@ -1,12 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./CurrentStateCompare.module.css";
-
 
 // 컴포넌트
 import PageNav from "components/PageNav";
-import DataRowSetRender from "components/DataRowSetRender"
+import DataRowSetRender from "components/DataRowSetRender";
 import Pagination from "components/common/Pagination";
-import Dropdown from "components/common/Dropdown";
 import DropdownMiddleSize from "components/common/DropdownMiddleSize";
 
 // 커스텀 훅
@@ -19,12 +17,15 @@ function CurrentStateCompare() {
   // CompanyPerRow & HeaderColumns 컴포넌트 테스트용 데이터 데이터
   const { currentPage, totalPages, handlePageChange } = usePageHandler();
 
+  const [sortOption, setSortOption] = useState([""]);
+
   const dataObject = {
     id: "1",
     rank: "3",
     name: "코딩마스터",
     img: Companyimg,
-    description: "코딩마스터는 청소년들을 위한 코딩 교육 플랫폼을 운영하는 기업입니다.",
+    description:
+      "코딩마스터는 청소년들을 위한 코딩 교육 플랫폼을 운영하는 기업입니다.",
     category: "에듀테크",
     total_investment: 12312959459,
     revenue: 3245204304,
@@ -33,22 +34,36 @@ function CurrentStateCompare() {
     investmentInfactTotal: 342534123124,
     myCompanyChooseCount: 124123,
     CompareChoohseCount: 12315565,
-    userName: "정준호", 
-    userRank: 3, 
-    userTotalInvestment: 3423401234, 
-    userComment: "테스트입니다." 
-  }
+    userName: "정준호",
+    userRank: 3,
+    userTotalInvestment: 3423401234,
+    userComment: "테스트입니다.",
+  };
 
   // 테스트용 데이터 세트
-  const dataList = [dataObject, dataObject, dataObject, dataObject, dataObject, dataObject, dataObject, dataObject, dataObject, dataObject ]
+  const dataList = [
+    dataObject,
+    dataObject,
+    dataObject,
+    dataObject,
+    dataObject,
+    dataObject,
+    dataObject,
+    dataObject,
+    dataObject,
+    dataObject,
+  ];
 
+  const handleOptionChange = (option) => {
+    setSortOption(option);
+  };
 
   const options = [
     "나의 기업 선택 횟수 높은순",
     "나의 기업 선택 횟수 낮은순",
     "실제 누적 투자 금액 높은순",
-    "실제 누적 투자 금액 낮은순"
-  ]
+    "실제 누적 투자 금액 낮은순",
+  ];
 
   return (
     <div className={styles.bgSet}>
@@ -58,14 +73,13 @@ function CurrentStateCompare() {
       <main className={styles.mainContainer}>
         <header className={styles.headerBox}>
           <span className={styles.headerText}>투자 현황</span>
-          <DropdownMiddleSize options={options}/>
+          <DropdownMiddleSize
+            options={options}
+            handleOptionChange={handleOptionChange}
+          />
         </header>
         <section>
-          <DataRowSetRender
-            type="invest"
-            dataList={dataList}
-
-          />
+          <DataRowSetRender type="invest" dataList={dataList} />
         </section>
       </main>
       <footer className={styles.footerSet}>

--- a/vms_fe/src/pages/CurrentStateCompare.js
+++ b/vms_fe/src/pages/CurrentStateCompare.js
@@ -79,7 +79,7 @@ function CurrentStateCompare() {
           />
         </header>
         <section>
-          <DataRowSetRender type="invest" dataList={dataList} />
+          <DataRowSetRender type="choose" dataList={dataList} />
         </section>
       </main>
       <footer className={styles.footerSet}>

--- a/vms_fe/src/pages/CurrentStateCompare.module.css
+++ b/vms_fe/src/pages/CurrentStateCompare.module.css
@@ -25,7 +25,6 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 0px 24px; 
   gap: 28px;
 }
 
@@ -45,9 +44,5 @@
 @media (max-width: 744px) {
   .mainContainer {
     padding: 24px 16px;
-  }
-
-  .headerBox {
-    padding: 0px 16px;
   }
 }

--- a/vms_fe/src/pages/CurrentStateCompare.module.css
+++ b/vms_fe/src/pages/CurrentStateCompare.module.css
@@ -25,6 +25,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  padding: 0px 24px; 
   gap: 28px;
 }
 
@@ -44,5 +45,9 @@
 @media (max-width: 744px) {
   .mainContainer {
     padding: 24px 16px;
+  }
+
+  .headerBox {
+    padding: 0px 16px;
   }
 }


### PR DESCRIPTION
### 추가사항
- [X] 비교 현황 페이지 - CurrentStateCompare 페이지
  - 특이사항
    - 피그마와는 다르게 page 우측에 padding 적용하여 여백 추가
    - 피그마 화면
    <img width="362" alt="image" src="https://github.com/user-attachments/assets/d4f5fbe5-e573-4b35-9381-5d6a28c2cd19">

    - 작업 화면
    <img width="257" alt="image" src="https://github.com/user-attachments/assets/e2e453df-07f8-452e-a08b-996caad3a2f9">


### 진행예정
- 추후 데이터 연결 

### 테스트 완료 여부
- [x] 테스트 완료
  - 기본 렌더링 
  <img width="1154" alt="image" src="https://github.com/user-attachments/assets/714c926e-43fd-4717-b67d-5a2cc8b7265f">

  - 반응형 렌더링 - 태블릿
  ![image](https://github.com/user-attachments/assets/0ea24802-15c0-4b98-b366-5d8ad4136b93)


  - 반응형 렌더링 - 모바일
  ![image](https://github.com/user-attachments/assets/681b67f0-6145-4cad-a371-347afbebba2d)



### 문제점
- 특이사항 없음
