### PR TITLE
[김소희 ] CurrentStateInvest page 추가

### DIFF
--- a/vms_fe/src/pages/CurrentStateInvest.js
+++ b/vms_fe/src/pages/CurrentStateInvest.js
@@ -86,7 +86,7 @@ function CurrentStateInvest() {
     "실제 누적 투자 금액 낮은순",
   ];
 
-  // 옵션 별 정렬
+  // 옵션 별 정렬 ( 백엔드에서 구현시, 삭제예정 )
   useEffect(() => {
     let sorted = [...mockData];
     switch (selectedOption) {

--- a/vms_fe/src/pages/CurrentStateInvest.module.css
+++ b/vms_fe/src/pages/CurrentStateInvest.module.css
@@ -40,3 +40,9 @@ p {
   margin-top: 40px;
   padding-bottom: 133px;
 }
+
+@media (max-width: 744px) {
+  .investCompanyList .currentStateInvest {
+    padding: 24px 16px;
+  }
+}


### PR DESCRIPTION
### 추가사항
- 투자 현황 페이지를 구현하였습니다.
- 정렬 기능과 테스트할 데이터를 같이 추가해뒀는데 추후 삭제예정입니다.

### 진행예정
- 백엔드 API 구현 예정

### 테스트 완료 여부 
- [x] 테스트 완료

### 문제점
- 없음

### 스크린샷
1) pc 버전
![스크린샷_21-8-2024_163759_localhost](https://github.com/user-attachments/assets/67664eae-9b2b-4d9a-af2f-d36dfa77ad59)

2) tablet 버전
![스크린샷_21-8-2024_164056_localhost](https://github.com/user-attachments/assets/09a91556-3055-4d2f-9e40-fecb37d545f0)

3) mobile 버전
![image](https://github.com/user-attachments/assets/48f194df-9a06-4883-9ced-237b32dda848)