### PR TITLE
[김민서] MyCompanyCompare page 추가 (정렬 기능 추가)

### DIFF
--- a/vms_fe/src/pages/MyCompanyCompare.js
+++ b/vms_fe/src/pages/MyCompanyCompare.js
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./MyCompanyCompare.module.css";
 import PageNav from "components/PageNav";
 import MediumBtn from "components/common/MediumBtn";
 import DropdownMiddleSize from "components/common/DropdownMiddleSize";
 import DataRowSetRenderNoRank from "../components/DataRowSetRenderNoRank";
+import DataRowSetRender from "../components/DataRowSetRender";
 import icCircle from "../assets/images/ic_circle.svg";
 import icPlus from "../assets/images/ic_plus.svg";
 import icRestart from "../assets/images/ic_restart.svg";
@@ -17,6 +18,7 @@ function MyCompanyCompare() {
   const [additionalCompanies, setAdditionalCompanies] = useState([]);
   const [isComparisonVisible, setIsComparisonVisible] = useState(false);
   const [sortingOption, setSortingOption] = useState("매출액 높은순");
+  const [sortedCompanies, setSortedCompanies] = useState([]);
 
   const openModal = () => {
     setIsModalOpen(true);
@@ -29,11 +31,13 @@ function MyCompanyCompare() {
   const closeModal = (companies) => {
     setSelectedCompanies(companies);
     setIsModalOpen(false);
+    sortCompanies(companies.concat(additionalCompanies), sortingOption);
   };
 
   const closeAdditionalModal = (companies) => {
     setAdditionalCompanies(companies);
     setIsAdditionalModalOpen(false);
+    sortCompanies(selectedCompanies.concat(companies), sortingOption);
   };
 
   const removeCompany = (index, isAdditional) => {
@@ -46,14 +50,51 @@ function MyCompanyCompare() {
     } else {
       setSelectedCompanies(newCompanies);
     }
+    sortCompanies(selectedCompanies.concat(additionalCompanies), sortingOption);
   };
 
   const handleSortingChange = (option) => {
     setSortingOption(option);
+    sortCompanies(selectedCompanies.concat(additionalCompanies), option);
+  };
+
+  const sortCompanies = (companies, option) => {
+    const sortedList = [...companies];
+
+    switch (option) {
+      case "누적 투자금액 높은순":
+        sortedList.sort((a, b) => b.total_investment - a.total_investment);
+        break;
+      case "누적 투자금액 낮은순":
+        sortedList.sort((a, b) => a.total_investment - b.total_investment);
+        break;
+      case "매출액 높은순":
+        sortedList.sort((a, b) => b.revenue - a.revenue);
+        break;
+      case "매출액 낮은순":
+        sortedList.sort((a, b) => a.revenue - b.revenue);
+        break;
+      case "고용 인원 많은순":
+        sortedList.sort((a, b) => b.employees - a.employees);
+        break;
+      case "고용 인원 적은순":
+        sortedList.sort((a, b) => a.employees - b.employees);
+        break;
+      default:
+        break;
+    }
+
+    const rankedList = sortedList.map((company, index) => ({
+      ...company,
+      rank: index + 1,
+    }));
+
+    setSortedCompanies(rankedList);
   };
 
   const handleComparisonClick = () => {
     setIsComparisonVisible(true);
+    sortCompanies(selectedCompanies.concat(additionalCompanies), sortingOption);
   };
 
   return (
@@ -139,8 +180,8 @@ function MyCompanyCompare() {
               </div>
               <div className={styles.dataRowWrapper}>
                 <DataRowSetRenderNoRank
-                  type="noRank" // 다시 noRank 타입으로 전달
-                  dataList={selectedCompanies.concat(additionalCompanies)}
+                  type="noRank"
+                  dataList={sortedCompanies}
                 />
               </div>
             </div>
@@ -164,9 +205,9 @@ function MyCompanyCompare() {
                 />
               </div>
               <div className={styles.dataRowWrapper}>
-                <DataRowSetRenderNoRank
-                  type="rank" // rank 타입으로 전달
-                  dataList={selectedCompanies.concat(additionalCompanies)}
+                <DataRowSetRender
+                  type="rank"
+                  dataList={sortedCompanies}
                 />
               </div>
             </div>


### PR DESCRIPTION
### 추가사항
- 전에 pr에 이어 나의 기업과 다른 기업간의 비교를 할 수 있는 페이지 입니다.
- 정렬, 순위 기능 추가했습니다.

### 전의 pr에서 수정되거나 추가되어야 할 사항
- [ ] 나의 기업에서 기업을 하나 선택하면 모달 닫히게 하기
- [x] 회사 로고 사진이 안들어지는거 해결
![image](https://github.com/user-attachments/assets/2ac376b1-82c9-4f75-b5e9-01ff7c4f14c9)
- [x] 비교할 기업들 CompanyCard 간격 조절
- [ ] 모바일 버전 미디어 쿼리 재배치
- [ ] 비교할 기업 넣기 전까지 기업 비교하기 버튼 비활성화
- [ ] 버튼들 (전체 초기화, 기업 추가하기) 크기 독립적으로 크기 설정
- [ ] 나의 기업 추가 innerBox 랑 비교할 기업 추가 infoBox랑 독립적으로 설정
- [x] 각 기업들간의 비교 결괏값
![image](https://github.com/user-attachments/assets/0378ee0f-f097-4a1b-86be-cb133a68eb5a)
![image](https://github.com/user-attachments/assets/5095623f-eea8-4b1b-852f-0ae011298a09)



### 테스트 완료 여부
- [x] 테스트 완료

### 문제점
=> 구현 못한 사항들 다음 pr에 이어서 진행 예정
## 스크린샷
- 전에 pr 이후에 추가된 내용만 첨부할 예정입니다!