### PR TITLE
[김민서] 기업 리스트 조회 API 구현

### DIFF
--- a/vms_be/src/routes/companyRoutes.js
+++ b/vms_be/src/routes/companyRoutes.js
@@ -21,6 +21,17 @@ router.get("/", async (req, res) => {
     const orderBy = {};
     orderBy[sort_by] = order;
 
+    // 페이지네이션 및 검색, 정렬 적용된 기업 리스트 조회
+    const companies = await prisma.company.findMany({
+      where: filter,
+      orderBy: orderBy,
+      skip: (parseInt(page) - 1) * parseInt(limit),
+      take: parseInt(limit),
+    });
+
+    // 전체 기업 수 조회 (페이지네이션을 위한 전체 항목 수)
+    const total = await prisma.company.count({ where: filter });
+
 
 // 기업 상세 조회 API
 router.get("/:companyId", async (req, res) => {

--- a/vms_be/src/routes/companyRoutes.js
+++ b/vms_be/src/routes/companyRoutes.js
@@ -4,7 +4,23 @@ import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 const router = express.Router();
 
-// 기업 관련 API 작성
+// 기업 리스트 조회 API
+router.get("/", async (req, res) => {
+  const { page = 1, limit = 10, search = '', sort_by = 'name', order = 'asc' } = req.query;
+
+  try {
+    // 검색 기능: 이름 또는 카테고리를 기준으로 검색
+    const filter = search ? {
+      OR: [
+        { name: { contains: search, mode: 'insensitive' } },
+        { category: { contains: search, mode: 'insensitive' } }
+      ]
+    } : {};
+
+    // 정렬 기능: 기본값은 이름 오름차순
+    const orderBy = {};
+    orderBy[sort_by] = order;
+
 
 // 기업 상세 조회 API
 router.get("/:companyId", async (req, res) => {

--- a/vms_be/src/routes/companyRoutes.js
+++ b/vms_be/src/routes/companyRoutes.js
@@ -32,6 +32,18 @@ router.get("/", async (req, res) => {
     // 전체 기업 수 조회 (페이지네이션을 위한 전체 항목 수)
     const total = await prisma.company.count({ where: filter });
 
+    // 응답 데이터
+    res.json({
+      page: parseInt(page),
+      limit: parseInt(limit),
+      total: total,
+      companies: companies,
+    });
+  } catch (error) {
+    // 서버 오류 발생 시
+    res.status(500).json({ error: "기업 리스트를 가져오는 중 오류가 발생했습니다." });
+  }
+});
 
 // 기업 상세 조회 API
 router.get("/:companyId", async (req, res) => {


### PR DESCRIPTION
### 추가사항
- 기업 리스트 조회 API (GET /api/companies)
- 페이지네이션, 검색, 정렬 기능 포함

### 진행예정
- 다른 팀원들의 API까지 모두 main 브랜치로 머지한 후, 프론트엔드 폴더에서 각자가 맡은 페이지에 필요한 API를 직접 추출하여 해당 페이지를 수정할 예정

### 테스트 완료 여부
- [x] 테스트 완료

### 문제점
- 없음

### 스크린샷
#### **로컬 서버에서 기업 리스트 조회**
<img width="697" alt="image" src="https://github.com/user-attachments/assets/381bfacf-f6ba-4241-b312-7eb3b9428116">

#### **로컬 서버에서 페이지네이션 테스트 (2번째 페이지, 5개의 항목)**
<img width="699" alt="image" src="https://github.com/user-attachments/assets/68c1ae51-2ca3-4cd3-bc3c-3dbfe7e2e1fd">

#### **로컬 서버에서 검색 기능 테스트 (이름 또는 카테고리에 "에듀" 포함)**
<img width="698" alt="image" src="https://github.com/user-attachments/assets/d5719b6d-745a-4443-ad9a-e7651e5a0103">

#### **로컬 서버에서 정렬 기능 테스트 (매출액 내림차순 정렬)**
<img width="697" alt="image" src="https://github.com/user-attachments/assets/f81da412-0a39-48fc-b104-08ea109304af">

#### **로컬 서버에서 잘못된 페이지네이션 입력 테스트 (잘못된 페이지 값)**
<img width="697" alt="image" src="https://github.com/user-attachments/assets/091c0892-ae22-4b07-a019-e4004b76b1a9">

#### **로컬 서버에서 잘못된 정렬 옵션 테스트 (존재하지 않는 정렬 기준)**
<img width="696" alt="image" src="https://github.com/user-attachments/assets/03f6fbfe-a528-4994-91ea-5f2e05ee01fa">








