### PR TITLE
[김민서] MyCompanyCompare 페이지: AddCompanyBtn, CompareCompanyBtn, CompareOtherCompanyBtn, ResetBtn 추가 및 버튼 조건 추가, 모바일에서의 반응형 개선

### DIFF
--- a/vms_fe/src/components/common/AddCompanyBtn.js
+++ b/vms_fe/src/components/common/AddCompanyBtn.js
@@ -1,0 +1,19 @@
+import React from "react";
+import styles from "./AddCompanyBtn.module.css";
+
+const AddCompanyBtn = ({ text, onClick, disabled = false }) => {
+  return (
+    <div className={styles.buttonWrapper}>
+      <button
+        className={`${styles.addCompanyBtn} ${disabled ? styles.disabledBtn : styles.active}`}
+        onClick={onClick}
+        disabled={disabled}  // 이 속성을 통해 버튼을 비활성화
+      >
+        {text}
+      </button>
+    </div>
+  );
+};
+
+export default AddCompanyBtn;
+

--- a/vms_fe/src/components/common/AddCompanyBtn.module.css
+++ b/vms_fe/src/components/common/AddCompanyBtn.module.css
@@ -1,0 +1,52 @@
+.buttonWrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%; 
+}
+
+.addCompanyBtn {
+    background-color: var(--black-100);
+    color: var(--gray-200);
+    border-radius: 50px;
+    border: none;
+    width: 135px;
+    height: 40px;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 19.09px;
+    padding: 8px, 24px, 8px, 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.addCompanyBtn.active {
+    background-color: var(--brand-orange);
+    color: var(--white);
+}
+
+.addCompanyBtn.disabledBtn {
+    background-color: #2E2E2E !important;
+    color: #747474 !important;
+    cursor: not-allowed !important; 
+}
+
+@media (min-width: 744px) and (max-width: 1199px) {
+    .addCompanyBtn {
+        width: 135px;
+        height: 40px;
+        font-size: 16px;
+        line-height: 19.09px;
+    }
+}
+
+@media (max-width: 743px) {
+    .addCompanyBtn {
+        width: 100px;
+        height: 32px;
+        font-size: 14px;
+        line-height: 16.71px;
+    }
+}
+

--- a/vms_fe/src/components/common/CompanyCard.module.css
+++ b/vms_fe/src/components/common/CompanyCard.module.css
@@ -61,8 +61,8 @@
 
 @media (max-width: 743px) {
   .companyCard {
-    width: 104px; /* 모바일 버전 카드 너비 */
-    height: 163px; /* 모바일 버전 카드 높이 */
+    width: 95px; /* 모바일 버전 카드 너비 */
+    height: 160px; /* 모바일 버전 카드 높이 */
     border-radius: 8px;
   }
 

--- a/vms_fe/src/components/common/CompareCompanyBtn.js
+++ b/vms_fe/src/components/common/CompareCompanyBtn.js
@@ -1,0 +1,19 @@
+import React from "react";
+import styles from "./CompareCompanyBtn.module.css";
+
+const CompareCompanyBtn = ({ text, onClick, disabled = false }) => {
+  return (
+    <div className={styles.buttonWrapper}>
+      <button
+        className={`${styles.compareCompanyBtn} ${disabled ? styles.disabledBtn : styles.active}`}
+        onClick={onClick}
+        disabled={disabled}  // 이 속성을 통해 버튼을 비활성화
+      >
+        {text}
+      </button>
+    </div>
+  );
+};
+
+export default CompareCompanyBtn;
+

--- a/vms_fe/src/components/common/CompareCompanyBtn.module.css
+++ b/vms_fe/src/components/common/CompareCompanyBtn.module.css
@@ -1,0 +1,53 @@
+.buttonWrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%; 
+}
+
+.compareCompanyBtn {
+    background-color: var(--black-100);
+    color: var(--gray-200);
+    border-radius: 50px;
+    border: none;
+    width: 183px;
+    height: 48px;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 19.09px;
+    padding: 13px, 48px, 13px, 48px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.compareCompanyBtn.active {
+    background-color: var(--brand-orange);
+    color: var(--white);
+}
+
+.compareCompanyBtn.disabledBtn {
+    background-color: #2E2E2E !important;
+    color: #747474 !important;
+    cursor: not-allowed !important; 
+}
+
+@media (min-width: 744px) and (max-width: 1199px) {
+    .compareCompanyBtn {
+        width: 183px;
+        height: 48px;
+        font-size: 16px;
+        padding: 13px, 48px, 13px, 48px;
+        line-height: 19.09px;
+    }
+}
+
+@media (max-width: 743px) {
+    .compareCompanyBtn {
+        width: 183px;
+        height: 48px;
+        font-size: 16px;
+        line-height: 19.09px;
+    }
+}
+

--- a/vms_fe/src/components/common/CompareOtherCompanyBtn.js
+++ b/vms_fe/src/components/common/CompareOtherCompanyBtn.js
@@ -1,0 +1,19 @@
+import React from "react";
+import styles from "./CompareOtherCompanyBtn.module.css";
+
+const CompareOtherCompanyBtn = ({ text, onClick, disabled = false }) => {
+  return (
+    <div className={styles.buttonWrapper}>
+      <button
+        className={`${styles.compareOtherCompanyBtn} ${disabled ? styles.disabledBtn : styles.active}`}
+        onClick={onClick}
+        disabled={disabled}  // 이 속성을 통해 버튼을 비활성화
+      >
+        {text}
+      </button>
+    </div>
+  );
+};
+
+export default CompareOtherCompanyBtn;
+

--- a/vms_fe/src/components/common/CompareOtherCompanyBtn.module.css
+++ b/vms_fe/src/components/common/CompareOtherCompanyBtn.module.css
@@ -1,0 +1,53 @@
+.buttonWrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%; 
+}
+
+.compareOtherCompanyBtn {
+    background-color: var(--black-100);
+    color: var(--gray-200);
+    border-radius: 50px;
+    border: none;
+    width: 167px;
+    height: 40px;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 19.09px;
+    padding: 8px, 24px, 8px, 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.compareOtherCompanyBtn.active {
+    background-color: var(--brand-orange);
+    color: var(--white);
+}
+
+.compareOtherCompanyBtn.disabledBtn {
+    background-color: #2E2E2E !important;
+    color: #747474 !important;
+    cursor: not-allowed !important; 
+}
+
+@media (min-width: 744px) and (max-width: 1199px) {
+    .compareOtherCompanyBtn {
+        width: 167px;
+        height: 40px;
+        font-size: 16px;
+        padding: 8px, 24px, 8px, 24px;
+        line-height: 19.09px;
+    }
+}
+
+@media (max-width: 743px) {
+    .compareOtherCompanyBtn {
+        width: 128px;
+        height: 32px;
+        font-size: 14px;
+        line-height: 116.71px;
+    }
+}
+

--- a/vms_fe/src/components/common/DropdownSmallSize.js
+++ b/vms_fe/src/components/common/DropdownSmallSize.js
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import styles from "./DropdownSmallSize.module.css";
+import ToggleIcon from "./../../assets/images/ic_toggle.svg";
+
+function DropdownSmallSize({
+  options = [
+    "누적 투자금액 높은순",
+    "누적 투자금액 낮은순",
+    "매출액 높은순",
+    "매출액 낮은순",
+    "고용 인원 많은순",
+    "고용 인원 적은순",
+  ],
+  initialLabel = options[0],
+  handleOptionChange,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedOption, setSelectedOption] = useState(initialLabel);
+
+  const toggleDropdown = () => setIsOpen(!isOpen);
+
+  const handleOptionClick = (option) => {
+    setSelectedOption(option);
+    setIsOpen(false);
+    handleOptionChange(option);
+  };
+
+  return (
+    <div className={styles.dropdown}>
+      <div
+        className={`${styles.dropdownToggle} ${isOpen ? styles.open : ""}`}
+        onClick={toggleDropdown}
+      >
+        <span className={styles.dropdownLabel}>{selectedOption}</span>
+        <img
+          src={ToggleIcon}
+          alt="Toggle Icon"
+          className={styles.dropdownIcon}
+        />
+      </div>
+      <ul
+        className={`${styles.dropdownMenu} ${
+          isOpen ? styles.dropdownMenuOpen : ""
+        }`}
+      >
+        {options.map((option, index) => (
+          <li
+            key={index}
+            className={styles.dropdownMenuItem}
+            onClick={() => handleOptionClick(option)}
+          >
+            {option}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default DropdownSmallSize;
+

--- a/vms_fe/src/components/common/DropdownSmallSize.module.css
+++ b/vms_fe/src/components/common/DropdownSmallSize.module.css
@@ -1,0 +1,133 @@
+/* 드롭다운 컨테이너 */
+.dropdown {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  max-width: 264px;
+  height: 40px;
+}
+
+/* 드롭다운 토글 버튼 */
+.dropdownToggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 12px 16px;
+  background-color: #131313;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 1px solid #747474;
+  overflow: hidden;
+  box-sizing: border-box;
+  transition: background-color 0.4s ease;
+}
+
+/* 드롭다운 라벨 */
+.dropdownLabel {
+  font-weight: 400;
+  font-size: 14px;
+  color: #d8d8d8;
+  text-align: left;
+  margin-right: 10px;
+  white-space: nowrap;
+}
+
+.dropdownIcon {
+  width: 22px;
+  height: 22px;
+  margin-left: auto;
+  transition: transform 0.4s ease;
+}
+
+.dropdownToggle.open .dropdownIcon {
+  transform: rotate(180deg);
+}
+
+.dropdownMenu {
+  position: absolute;
+  margin-top: 8px;
+  width: 100%;
+  max-width: 264px;
+  background-color: #131313;
+  border-radius: 10px;
+  border: 1px solid #747474;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 0.4s ease-out, opacity 0.4s ease-out;
+}
+
+.dropdownMenuOpen {
+  max-height: 500px;
+  opacity: 1;
+}
+
+/* 드롭다운 메뉴 아이템 */
+.dropdownMenu li:not(:last-child) {
+  border-bottom: 1px solid #747474;
+}
+
+.dropdownMenu li:hover:not(:last-child):not(:first-child) {
+  background-color: #333333;
+}
+
+.dropdownMenu li:hover:first-child {
+  border-radius: 10px 10px 0 0;
+  background-color: #333333;
+}
+
+.dropdownMenu li:hover:last-child {
+  border-radius: 0 0 10px 10px;
+  background-color: #333333;
+}
+
+.dropdownMenuItem {
+  height: 40px;
+  padding: 0 10px;
+  font-weight: 400;
+  font-size: 14px;
+  color: #d8d8d8;
+  text-align: center;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 모바일 버전 (화면 크기 743px ~ 375px) */
+@media (max-width: 744px) {
+  .dropdown {
+    width: 100%;
+    max-width: 146px;
+  }
+
+  .dropdownToggle {
+    padding: 8px 12px;
+    width: 146px;
+    height: 40px;
+  }
+
+  .dropdownLabel {
+    font-size: 12px;
+    line-height: 14px;
+  }
+
+  .dropdownIcon {
+    width: 20px;
+    height: 20px;
+  }
+
+  .dropdownMenu {
+    width: 100%;
+    max-width: 146px;
+    max-height: 228px;
+  }
+
+  .dropdownMenuItem {
+    height: 38px;
+    font-size: 12px;
+  }
+}
+

--- a/vms_fe/src/components/common/ResetBtn.js
+++ b/vms_fe/src/components/common/ResetBtn.js
@@ -1,0 +1,19 @@
+import React from "react";
+import styles from "./ResetBtn.module.css";  // 파일 이름도 변경해주어야 합니다
+
+const ResetBtn = ({ text, onClick, disabled = false }) => {
+  return (
+    <div className={styles.buttonWrapper}>
+      <button
+        className={`${styles.resetBtn} ${disabled ? styles.disabledBtn : styles.active}`}
+        onClick={onClick}
+        disabled={disabled}  // 이 속성을 통해 버튼을 비활성화
+      >
+        {text}
+      </button>
+    </div>
+  );
+};
+
+export default ResetBtn;
+

--- a/vms_fe/src/components/common/ResetBtn.module.css
+++ b/vms_fe/src/components/common/ResetBtn.module.css
@@ -1,0 +1,52 @@
+.buttonWrapper {
+    display: flex;
+    justify-content: center;
+    width: 100%; 
+}
+
+.resetBtn {
+    background-color: var(--black-100);
+    color: var(--gray-200);
+    border-radius: 50px;
+    border: none;
+    width: 149px;
+    height: 40px;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 19.09px;
+    padding: 8px, 24px, 8px, 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.resetBtn.active {
+    background-color: var(--brand-orange);
+    color: var(--white);
+}
+
+.resetBtn.disabledBtn {
+    background-color: #2E2E2E !important;
+    color: #747474 !important;
+    cursor: not-allowed !important; 
+}
+
+@media (min-width: 744px) and (max-width: 1199px) {
+    .resetBtn {
+        width: 149px;
+        height: 40px;
+        font-size: 16px;
+        line-height: 19.09px;
+    }
+}
+
+@media (max-width: 743px) {
+    .resetBtn {
+        width: 116px;
+        height: 32px;
+        font-size: 14px;
+        line-height: 16.71px;
+    }
+}
+

--- a/vms_fe/src/components/common/SearchBar.module.css
+++ b/vms_fe/src/components/common/SearchBar.module.css
@@ -46,8 +46,7 @@
 
 @media (max-width: 743px) {
   .searchBar {
-    width: 189px;
-    min-width: 189px;
+    width: 300px;
     height: 40px;
   }
 

--- a/vms_fe/src/pages/MyCompanyCompare.js
+++ b/vms_fe/src/pages/MyCompanyCompare.js
@@ -1,20 +1,35 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./MyCompanyCompare.module.css";
 import PageNav from "components/PageNav";
-import ResetBtn from "components/common/ResetBtn";
+import AddCompanyBtn from "components/common/AddCompanyBtn";
+import CompareCompanyBtn from "components/common/CompareCompanyBtn";
 import CompareOtherCompanyBtn from "components/common/CompareOtherCompanyBtn";
+import ResetBtn from "components/common/ResetBtn";
+import DropdownSmallSize from "components/common/DropdownSmallSize";
+import DataRowSetRenderNoRank from "../components/DataRowSetRenderNoRank";
+import DataRowSetRender from "../components/DataRowSetRender";
+import icCircle from "../assets/images/ic_circle.svg";
+import icPlus from "../assets/images/ic_plus.svg";
 import icRestart from "../assets/images/ic_restart.svg";
 import ModalSelectComparision from "../components/ModalSelectComparision";
 import CompanyCard from "../components/common/CompanyCard";
 
 function MyCompanyCompare() {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isAdditionalModalOpen, setIsAdditionalModalOpen] = useState(false);
   const [selectedCompanies, setSelectedCompanies] = useState([]);
+  const [additionalCompanies, setAdditionalCompanies] = useState([]);
   const [isComparisonVisible, setIsComparisonVisible] = useState(false);
+  const [sortingOption, setSortingOption] = useState("매출액 높은순");
+  const [sortedCompanies, setSortedCompanies] = useState([]);
   const [resetButtonText, setResetButtonText] = useState("전체 초기화");
 
   const openModal = () => {
     setIsModalOpen(true);
+  };
+
+  const openAdditionalModal = () => {
+    setIsAdditionalModalOpen(true);
   };
 
   const closeModal = (companies) => {
@@ -22,17 +37,78 @@ function MyCompanyCompare() {
     setIsModalOpen(false);
   };
 
+  const closeAdditionalModal = (companies) => {
+    setAdditionalCompanies(companies);
+    setIsAdditionalModalOpen(false);
+  };
+
+  const removeCompany = (index, isAdditional) => {
+    const newCompanies = isAdditional
+      ? [...additionalCompanies]
+      : [...selectedCompanies];
+    newCompanies.splice(index, 1);
+    if (isAdditional) {
+      setAdditionalCompanies(newCompanies);
+    } else {
+      setSelectedCompanies(newCompanies);
+    }
+  };
+
+  const handleSortingChange = (option) => {
+    setSortingOption(option);
+    sortCompanies(selectedCompanies.concat(additionalCompanies), option);
+  };
+
+  const sortCompanies = (companies, option) => {
+    const sortedList = [...companies];
+
+    switch (option) {
+      case "누적 투자금액 높은순":
+        sortedList.sort((a, b) => b.total_investment - a.total_investment);
+        break;
+      case "누적 투자금액 낮은순":
+        sortedList.sort((a, b) => a.total_investment - b.total_investment);
+        break;
+      case "매출액 높은순":
+        sortedList.sort((a, b) => b.revenue - a.revenue);
+        break;
+      case "매출액 낮은순":
+        sortedList.sort((a, b) => a.revenue - b.revenue);
+        break;
+      case "고용 인원 많은순":
+        sortedList.sort((a, b) => b.employees - a.employees);
+        break;
+      case "고용 인원 적은순":
+        sortedList.sort((a, b) => a.employees - b.employees);
+        break;
+      default:
+        break;
+    }
+
+    const rankedList = sortedList.map((company, index) => ({
+      ...company,
+      rank: index + 1,
+    }));
+
+    setSortedCompanies(rankedList);
+  };
+
   const handleComparisonClick = () => {
     setIsComparisonVisible(true);
+    sortCompanies(selectedCompanies.concat(additionalCompanies), sortingOption);
     setResetButtonText("다른 기업 비교하기"); // 버튼 텍스트 변경
   };
+
+  // 기업 비교하기 버튼 활성화 조건
+  const isCompareButtonEnabled =
+    selectedCompanies.length > 0 && additionalCompanies.length > 0;
 
   const handleResetButtonClick = () => {
     if (resetButtonText === "전체 초기화") {
       setSelectedCompanies([]);
+      setAdditionalCompanies([]);
     } else if (resetButtonText === "다른 기업 비교하기") {
-      // 모달 열기
-      openModal();
+      openAdditionalModal();
     }
   };
 
@@ -40,6 +116,7 @@ function MyCompanyCompare() {
     <div className={styles.pageContainer}>
       <PageNav />
       <div className={styles.content}>
+        {/* "나의 기업을 선택해 주세요!" 부분 */}
         <div className={styles.subheadingWrapper}>
           <h1 className={styles.heading}>나의 기업을 선택해 주세요!</h1>
           <div className={styles.addCompanyBtnWrapper}>
@@ -81,11 +158,7 @@ function MyCompanyCompare() {
                   />
                   <p
                     className={styles.removeText}
-                    onClick={() => {
-                      const newCompanies = [...selectedCompanies];
-                      newCompanies.splice(index, 1);
-                      setSelectedCompanies(newCompanies);
-                    }}
+                    onClick={() => removeCompany(index, false)}
                   >
                     선택 취소
                   </p>
@@ -94,7 +167,12 @@ function MyCompanyCompare() {
             ) : (
               <div className={styles.addButtonWrapper}>
                 <div className={styles.addButton} onClick={openModal}>
-                  {/* 모달 열기 버튼 */}
+                  <img
+                    src={icCircle}
+                    alt="circle"
+                    className={styles.icCircle}
+                  />
+                  <img src={icPlus} alt="plus" className={styles.icPlus} />
                 </div>
                 <p className={styles.addText}>기업 추가</p>
               </div>
@@ -102,15 +180,124 @@ function MyCompanyCompare() {
           </div>
         </div>
 
-        {isComparisonVisible && (
-          <div className={styles.btnWrapper}>
-            <button
-              onClick={handleComparisonClick}
-              className={styles.compareButton}
-            >
-              기업 비교하기
-            </button>
-          </div>
+        {isComparisonVisible ? (
+          <>
+            {/* 비교 결과 확인하기 섹션 */}
+            <div className={styles.sectionWrapper}>
+              <div className={styles.headingWrapper}>
+                <h1 className={styles.heading}>비교 결과 확인하기</h1>
+                <DropdownSmallSize
+                  initialLabel="매출액 높은순"
+                  options={[
+                    "누적 투자금액 높은순",
+                    "누적 투자금액 낮은순",
+                    "매출액 높은순",
+                    "매출액 낮은순",
+                    "고용 인원 많은순",
+                    "고용 인원 적은순",
+                  ]}
+                  handleOptionChange={handleSortingChange}
+                  className={styles.dropdown}
+                />
+              </div>
+              <div className={styles.dataRowWrapper}>
+                <DataRowSetRenderNoRank
+                  type="noRank"
+                  dataList={sortedCompanies}
+                />
+              </div>
+            </div>
+
+            {/* 기업 순위 확인하기 섹션 */}
+            <div className={styles.sectionWrapper}>
+              <div className={styles.headingWrapper}>
+                <h1 className={styles.heading}>기업 순위 확인하기</h1>
+                <DropdownSmallSize
+                  initialLabel="매출액 높은순"
+                  options={[
+                    "누적 투자금액 높은순",
+                    "누적 투자금액 낮은순",
+                    "매출액 높은순",
+                    "매출액 낮은순",
+                    "고용 인원 많은순",
+                    "고용 인원 적은순",
+                  ]}
+                  handleOptionChange={handleSortingChange}
+                  className={styles.dropdown}
+                />
+              </div>
+              <div className={styles.dataRowWrapper}>
+                <DataRowSetRender type="rank" dataList={sortedCompanies} />
+              </div>
+            </div>
+
+            {/* "나의 기업에 투자하기" 버튼 */}
+            <div className={styles.btnWrapper}>
+              <CompareCompanyBtn
+                text="나의 기업에 투자하기"
+                onClick={() => {
+                }}
+                disabled={!isCompareButtonEnabled} // 버튼 활성화 조건 적용
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            {selectedCompanies.length > 0 && (
+              <>
+                <div className={styles.subheadingWrapper}>
+                  <h2 className={styles.subheading}>어떤 기업이 궁금하세요?</h2>
+                  <p className={styles.maxCompaniesText}>(최대 5개)</p>
+                  <div className={styles.addCompanyBtnWrapper}>
+                    <AddCompanyBtn
+                      text="기업 추가하기"
+                      className={styles.addCompanyBtn}
+                      onClick={openAdditionalModal}
+                    />
+                  </div>
+                </div>
+
+                <div className={styles.addOtherCompany}>
+                  <div className={styles.innerBox}>
+                    {additionalCompanies.length > 0 ? (
+                      additionalCompanies.map((company, index) => (
+                        <div
+                          key={index}
+                          className={styles.comparisonCompanyCardWrapper}
+                        >
+                          <CompanyCard
+                            name={company.name}
+                            category={company.category}
+                            logoSrc={company.logoSrc}
+                            showDeleteButton={true}
+                            showBackground={true}
+                            onDelete={() => removeCompany(index, true)}
+                          />
+                        </div>
+                      ))
+                    ) : (
+                      <div className={styles.noCompaniesInfo}>
+                        아직 추가한 기업이 없어요,
+                        <br />
+                        버튼을 눌러 기업을 추가해보세요!
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
+
+            <div className={styles.btnWrapper}>
+              <CompareCompanyBtn
+                text="기업 비교하기"
+                className={
+                  isCompareButtonEnabled ? styles.activeBtn : styles.disabledBtn
+                }
+                disabled={!isCompareButtonEnabled}
+                onClick={handleComparisonClick}
+              />
+            </div>
+          </>
         )}
       </div>
 
@@ -120,6 +307,14 @@ function MyCompanyCompare() {
         onClose={closeModal}
         title="나의 기업 선택하기"
         text="최근 선택된 기업"
+      />
+
+      {/* 비교할 기업 선택하기 모달 */}
+      <ModalSelectComparision
+        isOpen={isAdditionalModalOpen}
+        onClose={closeAdditionalModal}
+        title="비교할 기업 선택하기"
+        text="선택한 기업"
       />
     </div>
   );

--- a/vms_fe/src/pages/MyCompanyCompare.js
+++ b/vms_fe/src/pages/MyCompanyCompare.js
@@ -1,111 +1,47 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styles from "./MyCompanyCompare.module.css";
 import PageNav from "components/PageNav";
-import MediumBtn from "components/common/MediumBtn";
-import DropdownMiddleSize from "components/common/DropdownMiddleSize";
-import DataRowSetRenderNoRank from "../components/DataRowSetRenderNoRank";
-import DataRowSetRender from "../components/DataRowSetRender";
-import icCircle from "../assets/images/ic_circle.svg";
-import icPlus from "../assets/images/ic_plus.svg";
+import ResetBtn from "components/common/ResetBtn";
 import icRestart from "../assets/images/ic_restart.svg";
 import ModalSelectComparision from "../components/ModalSelectComparision";
 import CompanyCard from "../components/common/CompanyCard";
 
 function MyCompanyCompare() {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isAdditionalModalOpen, setIsAdditionalModalOpen] = useState(false);
   const [selectedCompanies, setSelectedCompanies] = useState([]);
-  const [additionalCompanies, setAdditionalCompanies] = useState([]);
   const [isComparisonVisible, setIsComparisonVisible] = useState(false);
-  const [sortingOption, setSortingOption] = useState("매출액 높은순");
-  const [sortedCompanies, setSortedCompanies] = useState([]);
+  const [resetButtonText, setResetButtonText] = useState("전체 초기화");
 
   const openModal = () => {
     setIsModalOpen(true);
   };
 
-  const openAdditionalModal = () => {
-    setIsAdditionalModalOpen(true);
-  };
-
   const closeModal = (companies) => {
     setSelectedCompanies(companies);
     setIsModalOpen(false);
-    sortCompanies(companies.concat(additionalCompanies), sortingOption);
-  };
-
-  const closeAdditionalModal = (companies) => {
-    setAdditionalCompanies(companies);
-    setIsAdditionalModalOpen(false);
-    sortCompanies(selectedCompanies.concat(companies), sortingOption);
-  };
-
-  const removeCompany = (index, isAdditional) => {
-    const newCompanies = isAdditional
-      ? [...additionalCompanies]
-      : [...selectedCompanies];
-    newCompanies.splice(index, 1);
-    if (isAdditional) {
-      setAdditionalCompanies(newCompanies);
-    } else {
-      setSelectedCompanies(newCompanies);
-    }
-    sortCompanies(selectedCompanies.concat(additionalCompanies), sortingOption);
-  };
-
-  const handleSortingChange = (option) => {
-    setSortingOption(option);
-    sortCompanies(selectedCompanies.concat(additionalCompanies), option);
-  };
-
-  const sortCompanies = (companies, option) => {
-    const sortedList = [...companies];
-
-    switch (option) {
-      case "누적 투자금액 높은순":
-        sortedList.sort((a, b) => b.total_investment - a.total_investment);
-        break;
-      case "누적 투자금액 낮은순":
-        sortedList.sort((a, b) => a.total_investment - b.total_investment);
-        break;
-      case "매출액 높은순":
-        sortedList.sort((a, b) => b.revenue - a.revenue);
-        break;
-      case "매출액 낮은순":
-        sortedList.sort((a, b) => a.revenue - b.revenue);
-        break;
-      case "고용 인원 많은순":
-        sortedList.sort((a, b) => b.employees - a.employees);
-        break;
-      case "고용 인원 적은순":
-        sortedList.sort((a, b) => a.employees - b.employees);
-        break;
-      default:
-        break;
-    }
-
-    const rankedList = sortedList.map((company, index) => ({
-      ...company,
-      rank: index + 1,
-    }));
-
-    setSortedCompanies(rankedList);
   };
 
   const handleComparisonClick = () => {
     setIsComparisonVisible(true);
-    sortCompanies(selectedCompanies.concat(additionalCompanies), sortingOption);
+    setResetButtonText("다른 기업 비교하기"); // 버튼 텍스트 변경
+  };
+
+  const handleResetButtonClick = () => {
+    if (resetButtonText === "전체 초기화") {
+      setSelectedCompanies([]);
+    } else if (resetButtonText === "다른 기업 비교하기") {
+      // 다른 동작 추가 예정
+    }
   };
 
   return (
     <div className={styles.pageContainer}>
       <PageNav />
       <div className={styles.content}>
-        {/* "나의 기업을 선택해 주세요!" 부분 */}
-        <div className={styles.headingWrapper}>
+        <div className={styles.subheadingWrapper}>
           <h1 className={styles.heading}>나의 기업을 선택해 주세요!</h1>
-          <div className={styles.resetBtnWrapper}>
-            <MediumBtn
+          <div className={styles.addCompanyBtnWrapper}>
+            <ResetBtn
               text={
                 <>
                   <img
@@ -113,11 +49,11 @@ function MyCompanyCompare() {
                     alt="restart"
                     className={styles.icRestart}
                   />
-                  &nbsp;전체 초기화
+                  &nbsp;{resetButtonText}
                 </>
               }
               disabled={selectedCompanies.length === 0}
-              onClick={() => setSelectedCompanies([])}
+              onClick={handleResetButtonClick}
             />
           </div>
         </div>
@@ -136,7 +72,11 @@ function MyCompanyCompare() {
                   />
                   <p
                     className={styles.removeText}
-                    onClick={() => removeCompany(index, false)}
+                    onClick={() => {
+                      const newCompanies = [...selectedCompanies];
+                      newCompanies.splice(index, 1);
+                      setSelectedCompanies(newCompanies);
+                    }}
                   >
                     선택 취소
                   </p>
@@ -145,12 +85,7 @@ function MyCompanyCompare() {
             ) : (
               <div className={styles.addButtonWrapper}>
                 <div className={styles.addButton} onClick={openModal}>
-                  <img
-                    src={icCircle}
-                    alt="circle"
-                    className={styles.icCircle}
-                  />
-                  <img src={icPlus} alt="plus" className={styles.icPlus} />
+                  {/* 모달 열기 버튼 */}
                 </div>
                 <p className={styles.addText}>기업 추가</p>
               </div>
@@ -158,120 +93,15 @@ function MyCompanyCompare() {
           </div>
         </div>
 
-        {isComparisonVisible ? (
-          <>
-            {/* 비교 결과 확인하기 섹션 */}
-            <div className={styles.sectionWrapper}>
-              <div className={styles.headingWrapper}>
-                <h1 className={styles.heading}>비교 결과 확인하기</h1>
-                <DropdownMiddleSize
-                  initialLabel="매출액 높은순"
-                  options={[
-                    "누적 투자금액 높은순",
-                    "누적 투자금액 낮은순",
-                    "매출액 높은순",
-                    "매출액 낮은순",
-                    "고용 인원 많은순",
-                    "고용 인원 적은순",
-                  ]}
-                  handleOptionChange={handleSortingChange}
-                  className={styles.dropdown}
-                />
-              </div>
-              <div className={styles.dataRowWrapper}>
-                <DataRowSetRenderNoRank
-                  type="noRank"
-                  dataList={sortedCompanies}
-                />
-              </div>
-            </div>
-
-            {/* 기업 순위 확인하기 섹션 */}
-            <div className={styles.sectionWrapper}>
-              <div className={styles.headingWrapper}>
-                <h1 className={styles.heading}>기업 순위 확인하기</h1>
-                <DropdownMiddleSize
-                  initialLabel="매출액 높은순"
-                  options={[
-                    "누적 투자금액 높은순",
-                    "누적 투자금액 낮은순",
-                    "매출액 높은순",
-                    "매출액 낮은순",
-                    "고용 인원 많은순",
-                    "고용 인원 적은순",
-                  ]}
-                  handleOptionChange={handleSortingChange}
-                  className={styles.dropdown}
-                />
-              </div>
-              <div className={styles.dataRowWrapper}>
-                <DataRowSetRender
-                  type="rank"
-                  dataList={sortedCompanies}
-                />
-              </div>
-            </div>
-
-            {/* "나의 기업에 투자하기" 버튼 */}
-            <div className={styles.btnWrapper}>
-              <MediumBtn text="나의 기업에 투자하기" />
-            </div>
-          </>
-        ) : (
-          <>
-            {selectedCompanies.length > 0 && (
-              <>
-                <div className={styles.subheadingWrapper}>
-                  <h2 className={styles.subheading}>어떤 기업이 궁금하세요?</h2>
-                  <p className={styles.maxCompaniesText}>(최대 5개)</p>
-                  <div className={styles.addCompanyBtnWrapper}>
-                    <MediumBtn
-                      text="기업 추가하기"
-                      className={styles.addCompanyBtn}
-                      onClick={openAdditionalModal}
-                    />
-                  </div>
-                </div>
-
-                <div className={styles.infoBox}>
-                  <div className={styles.innerBox}>
-                    {additionalCompanies.length > 0 ? (
-                      additionalCompanies.map((company, index) => (
-                        <div
-                          key={index}
-                          className={styles.comparisonCompanyCardWrapper}
-                        >
-                          <CompanyCard
-                            name={company.name}
-                            category={company.category}
-                            logoSrc={company.logoSrc}
-                            showDeleteButton={true}
-                            showBackground={true}
-                            onDelete={() => removeCompany(index, true)}
-                          />
-                        </div>
-                      ))
-                    ) : (
-                      <div className={styles.noCompaniesInfo}>
-                        아직 추가한 기업이 없어요,
-                        <br />
-                        버튼을 눌러 기업을 추가해보세요!
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </>
-            )}
-
-            <div className={styles.btnWrapper}>
-              <MediumBtn
-                text="기업 비교하기"
-                className={selectedCompanies.length === 0 ? styles.disabledBtn : ""}
-                disabled={selectedCompanies.length === 0}
-                onClick={handleComparisonClick}
-              />
-            </div>
-          </>
+        {isComparisonVisible && (
+          <div className={styles.btnWrapper}>
+            <button
+              onClick={handleComparisonClick}
+              className={styles.compareButton}
+            >
+              기업 비교하기
+            </button>
+          </div>
         )}
       </div>
 
@@ -281,14 +111,6 @@ function MyCompanyCompare() {
         onClose={closeModal}
         title="나의 기업 선택하기"
         text="최근 선택된 기업"
-      />
-
-      {/* 비교할 기업 선택하기 모달 */}
-      <ModalSelectComparision
-        isOpen={isAdditionalModalOpen}
-        onClose={closeAdditionalModal}
-        title="비교할 기업 선택하기"
-        text="선택한 기업"
       />
     </div>
   );

--- a/vms_fe/src/pages/MyCompanyCompare.js
+++ b/vms_fe/src/pages/MyCompanyCompare.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import styles from "./MyCompanyCompare.module.css";
 import PageNav from "components/PageNav";
 import ResetBtn from "components/common/ResetBtn";
+import CompareOtherCompanyBtn from "components/common/CompareOtherCompanyBtn";
 import icRestart from "../assets/images/ic_restart.svg";
 import ModalSelectComparision from "../components/ModalSelectComparision";
 import CompanyCard from "../components/common/CompanyCard";
@@ -30,7 +31,8 @@ function MyCompanyCompare() {
     if (resetButtonText === "전체 초기화") {
       setSelectedCompanies([]);
     } else if (resetButtonText === "다른 기업 비교하기") {
-      // 다른 동작 추가 예정
+      // 모달 열기
+      openModal();
     }
   };
 
@@ -41,20 +43,27 @@ function MyCompanyCompare() {
         <div className={styles.subheadingWrapper}>
           <h1 className={styles.heading}>나의 기업을 선택해 주세요!</h1>
           <div className={styles.addCompanyBtnWrapper}>
-            <ResetBtn
-              text={
-                <>
-                  <img
-                    src={icRestart}
-                    alt="restart"
-                    className={styles.icRestart}
-                  />
-                  &nbsp;{resetButtonText}
-                </>
-              }
-              disabled={selectedCompanies.length === 0}
-              onClick={handleResetButtonClick}
-            />
+            {resetButtonText === "전체 초기화" ? (
+              <ResetBtn
+                text={
+                  <>
+                    <img
+                      src={icRestart}
+                      alt="restart"
+                      className={styles.icRestart}
+                    />
+                    &nbsp;{resetButtonText}
+                  </>
+                }
+                disabled={selectedCompanies.length === 0}
+                onClick={handleResetButtonClick}
+              />
+            ) : (
+              <CompareOtherCompanyBtn
+                text="다른 기업 비교하기"
+                onClick={handleResetButtonClick}
+              />
+            )}
           </div>
         </div>
 

--- a/vms_fe/src/pages/MyCompanyCompare.module.css
+++ b/vms_fe/src/pages/MyCompanyCompare.module.css
@@ -10,20 +10,24 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 90px;
   margin-left: auto;
   margin-right: auto;
   width: 100%;
-  max-width: 1156px;
+  max-width: 1200px;
   flex-grow: 1;
 }
 
-.headingWrapper, .sectionHeadingWrapper {
+.icRestart {
+  filter: brightness(0) invert(1); /* 흰색(#FFFFFF)으로 설정 */
+}
+
+.headingWrapper,
+.sectionHeadingWrapper {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: calc(100% - 48px);  /* Innerbox와 동일한 width */
-  min-width: 1108px; /* 최대 넓이를 지정하여 모든 headingWrapper가 동일하게 맞춰지도록 함 */
+  width: calc(100% - 3px); 
+  max-width: 1200px; /* 전체 페이지와 동일한 최대 너비 */
 }
 
 .heading {
@@ -34,25 +38,13 @@
   font-size: 20px;
 }
 
-.resetBtnWrapper {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
 .sectionWrapper {
   margin-top: 30px;
-  width: calc(100% - 48px);  /* Innerbox와 동일한 width */
+  width: calc(100% - 48px); /* Innerbox와 동일한 width */
   max-width: 1156px;
   display: flex;
   flex-direction: column;
   gap: 20px;
-}
-
-.sectionHeadingWrapper {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 }
 
 .sectionHeading {
@@ -64,12 +56,7 @@
 }
 
 .dataRowWrapper {
-  width: 100%;  /* Innerbox와 동일한 width */
-}
-
-.dropdown {
-  margin-left: auto;  /* 드롭다운이 오른쪽 끝으로 정렬되도록 설정 */
-  margin-right: 20px; /* 오른쪽으로 드롭다운을 더 이동시키기 위한 여백 추가 */
+  width: 100%; /* Innerbox와 동일한 width */
 }
 
 .addMyCompany {
@@ -85,17 +72,28 @@
   position: relative;
 }
 
+.addOtherCompany {
+  margin-top: 30px;
+  background-color: #212121;
+  width: calc(100% - 48px);
+  border-radius: 4px;
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
 .innerBox {
   background-color: #212121;
   height: 100%;
   width: 100%;
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   justify-content: center;
-  flex-direction: row;
-  gap: 5px; /* 카드 사이 간격을 줄임 */
   position: relative;
-  padding: 0 5px; /* 양쪽에 최소한의 패딩 추가 */
+  padding: 0 2px; 
+  gap: 1px; 
 }
 
 .myCompanyCardWrapper {
@@ -103,9 +101,9 @@
   align-items: center;
   justify-content: center;
   position: relative;
-  margin: 0; /* 카드 주변의 여백 제거 */
-  padding: 0; /* 카드 주변의 패딩 제거 */
-  flex: 1 1 auto; /* 카드가 가능한 공간을 채우도록 설정 */
+  margin: 0;
+  padding: 0;
+  flex: 1 1 calc(33.333% - 2px); /* 한 줄에 최대 3개씩 배치 */
 }
 
 .comparisonCompanyCardWrapper {
@@ -113,8 +111,8 @@
   align-items: center;
   justify-content: center;
   position: relative;
-  margin: 7px !important; /* 카드 주변의 여백 제거 */
-  padding: 0 !important; /* 카드 주변의 패딩 제거 */
+  margin: 5px !important;
+  padding: 0 !important;
 }
 
 .removeText {
@@ -131,9 +129,9 @@
 
 .subheadingWrapper {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
-  width: calc(100% - 48px);  /* Innerbox와 동일한 width */
+  width: calc(100% - 48px); /* Innerbox와 동일한 width */
   max-width: 1156px;
   margin-top: 30px;
 }
@@ -143,6 +141,7 @@
   font-family: "Pretendard", sans-serif;
   font-weight: 700;
   font-size: 20px;
+  margin-right: 6px;
 }
 
 .maxCompaniesText {
@@ -150,7 +149,65 @@
   font-family: "Pretendard", sans-serif;
   font-weight: 400;
   font-size: 16px;
-  margin-left: 10px;
+  margin-left: 6px;
+}
+
+/* 태블릿용 스타일 */
+@media (min-width: 744px) and (max-width: 1199px) {
+  .addMyCompany {
+    height: 240px; /* 태블릿에서 "나의 기업을 선택해주세요" 박스 height */
+  }
+
+  .addOtherCompany {
+    height: 240px; /* 태블릿에서 "어떤 기업이 궁금하세요" 박스 height */
+  }
+}
+
+/* 모바일 환경 스타일링 (743px ~ 375px) */
+@media (max-width: 743px) {
+  .heading,
+  .subheading {
+    font-size: calc(20px - 5px);
+    margin-right: 3px;
+  }
+
+  .maxCompaniesText {
+    font-size: calc(16px - 5px);
+    margin-left: 3px;
+  }
+
+  .addMyCompany {
+    height: 180px; /* 모바일에서 "나의 기업을 선택해주세요" 박스 height */
+  }
+
+  .addOtherCompany {
+    height: 350px; /* 모바일에서 "어떤 기업이 궁금하세요" 박스 height */
+  }
+
+  .innerBox {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 0 2px;
+    gap: 1px;
+  }
+
+  .myCompanyCardWrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    margin: 0;
+    padding: 0;
+    flex: 1 1 calc(33.333% - 2px);
+  }
+
+  .innerBox > .myCompanyCardWrapper:nth-child(4),
+  .innerBox > .myCompanyCardWrapper:nth-child(5) {
+    margin-left: auto;
+    margin-right: auto;
+    flex: 1 1 calc(33.333% - 2px);
+  }
 }
 
 .addCompanyBtnWrapper {
@@ -158,72 +215,6 @@
   justify-content: flex-end;
   align-items: center;
   margin-left: auto;
-}
-
-.addCompanyBtn {
-  width: calc(149px - 20px) !important;
-  height: 40px;
-  font-size: 16px;
-}
-
-/* 태블릿용 스타일 */
-@media (min-width: 744px) and (max-width: 1199px) {
-  .removeText {
-    top: -30px;
-    right: 30px;
-  }
-}
-
-@media (max-width: 743px) and (min-width: 375px) {
-  .infoBox {
-    height: 350px !important;
-  }
-
-  .innerBox {
-    height: 180px !important;
-  }
-
-  .infoBox .innerBox {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0px; /* 모바일 환경에서 카드 간격 더 줄이기 */
-  }
-
-  .myCompanyCardWrapper {
-    width: calc(33.333% - 10px);
-    margin-bottom: 5px;
-    display: flex;
-    justify-content: center;
-  }
-
-  .ccomparisonCompanyCardWrapper {
-    width: calc(33.333% - 10px);
-    display: flex;
-    justify-content: center;
-  }
-
-  .companyCardWrapper:nth-child(3n) {
-    margin-right: 0;
-  }
-
-  .companyCardWrapper:nth-child(3n+1) {
-    margin-left: 0;
-  }
-
-  .companyCardWrapper .companyCard {
-    width: calc(100% - 20px);
-    height: calc(100% - 20px);
-  }
-
-  .comparisonCompanyCardWrapper {
-    margin: 3px;
-  }
-
-  .companyCardWrapper .companyCard {
-    width: auto;
-    height: auto;
-  }
 }
 
 .addButtonWrapper {
@@ -265,18 +256,6 @@
   margin-top: 20px;
 }
 
-.infoBox {
-  margin-top: 30px;
-  background-color: #212121;
-  width: calc(100% - 48px);
-  border-radius: 4px;
-  height: 300px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0; /* infoBox 자체의 패딩 제거 */
-}
-
 .noCompaniesInfo {
   display: flex;
   justify-content: center;
@@ -302,7 +281,7 @@
 }
 
 .disabledBtn {
-  background-color: #2E2E2E !important;
+  background-color: #2e2e2e !important;
   color: #747474 !important;
   cursor: not-allowed !important;
 }

--- a/vms_fe/src/pages/MyCompanyCompare.module.css
+++ b/vms_fe/src/pages/MyCompanyCompare.module.css
@@ -30,6 +30,13 @@
   max-width: 1200px; /* 전체 페이지와 동일한 최대 너비 */
 }
 
+.dropdownWrapper {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-grow: 1; /* 드롭다운이 남은 공간을 모두 사용하도록 설정 */
+}
+
 .heading {
   color: #ffffff;
   font-family: "Pretendard", sans-serif;
@@ -92,8 +99,8 @@
   flex-wrap: wrap;
   justify-content: center;
   position: relative;
-  padding: 0 2px; 
-  gap: 1px; 
+  padding: 0 2px;
+  gap: 1px;
 }
 
 .myCompanyCardWrapper {
@@ -152,6 +159,8 @@
   margin-left: 6px;
 }
 
+
+
 /* 태블릿용 스타일 */
 @media (min-width: 744px) and (max-width: 1199px) {
   .addMyCompany {
@@ -207,6 +216,16 @@
     margin-left: auto;
     margin-right: auto;
     flex: 1 1 calc(33.333% - 2px);
+  }
+
+  .dropdown {
+    width: 146px !important;
+    height: 40px !important;
+  }
+
+  .dropdown .options {
+    width: 146px !important;
+    height: 228px !important;
   }
 }
 


### PR DESCRIPTION
### 추가사항
- [x] 전에 pr에 이어 나의 기업과 다른 기업간의 비교를 할 수 있는 페이지 입니다.
- [x] '나의 기업 선택하기' 모달과 '비교할 기업 선택하기' 모달에서 모두 회사를 선택한 경우에만 '기업 비교하기' 버튼이 활성화되도록 수정
- [x] 비교 시작 후 '전체 초기화' 버튼이 '다른 기업 비교하기'로 변경되도록 기능 추가
- [x] `MediumBtn` 을 분리하여 각각의 컴포넌트( `AddCompanyBtn`, `CompareCompanyBtn` , `CompareOtherCompanyBtn`, `ResetBtn` )로 새로 구현 및 적용
- [x] 버튼 텍스트에 따라 `ResetBtn` 과 `CompareOtherCompanyBtn` 컴포넌트가 조건부로 렌더링되도록 구현
- [x] 모바일 버전에서 `CompanyCard` 를 한 줄에 최대 3개씩 배치되도록 설정
- [x] `DropdownSmallSize` 컴포넌트 새로 구현
- [x] `DropdownSmallSize` 위치를 flex-end로 조정하여 오른쪽에 정렬되도록 수정
- [x] `SearchBar` 컴포넌트의 모바일 버전에서의 너비 조정
- [ ] 비교 결과 페이지에서 나의 기업에만 특정 CSS가 적용되어야 합니다

### 테스트 완료 여부
- [x] 테스트 완료

### 문제점
- '나의 기업 선택하기' 모달에서 기업을 하나 선택하면, 모달이 자동으로 닫히거나, 현재의 '비교할 기업 선택' 모달처럼 특정 개수 이상 선택할 수 없도록 해야 합니다.

### 스크린샷
### 모바일 버전입니다.
####  **나의 기업 비교 메인 페이지**
![image](https://github.com/user-attachments/assets/57801cf3-105a-459a-9903-16404f072454)

#### **나의 기업 비교 페이지 - 나의 기업만 선택한 경우, 기업 비교하기 버튼 비활성화**
![image](https://github.com/user-attachments/assets/f21e028b-e6ba-47cd-9601-8c015b54f57c)

#### **나의 기업 비교 페이지 - 나의 기업과 비교할 기업 둘 다 선택 시**
![image](https://github.com/user-attachments/assets/776df5aa-c1e5-426f-b469-b3fa9ac5e1d9)

#### **나의 기업 비교 페이지 - 기업 비교하기 버튼 클릭 시**
![image](https://github.com/user-attachments/assets/bd5a76b0-8293-4679-8f72-17e2eb7fce4c)

